### PR TITLE
Helpful error message on typo in args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.sqlite
 *.swo
 *.swp
+.envrc
 /tmp

--- a/bin/json2sqlite3
+++ b/bin/json2sqlite3
@@ -472,6 +472,7 @@ arg_updated_column=
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
   "--" )
+    shift 1
     break
     ;;
   "--after-query" | "--after-query="* )
@@ -655,11 +656,11 @@ json_file_length=0
 if [[ -s "${json_file}" ]]; then
   # SQLite3's 'json' mode will produce records in array<object> schema.
   # Here this is expecting that the input data is structured in the same way.
-  json_file_type="$(jq --raw-output 'type' < "${json_file}" || true)"
+  json_file_type="$(jq --raw-output 'type' < "${json_file}" 2>/dev/null || true)"
   if [[ "${json_file_type:-}" == "array" ]]; then
-    json_file_length="$(jq --raw-output 'length' < "${json_file}" || true)"
+    json_file_length="$(jq --raw-output 'length' < "${json_file}" 2>/dev/null || true)"
   else
-    echo "${0##*/}: error: input data is not an array: ${json_file}" 1>&2
+    error "${0##*/}: unexpected input data format: json: expected=array, got=${json_file_type:-unknown}"
     exit 1
   fi
 else

--- a/bin/json2sqlite3
+++ b/bin/json2sqlite3
@@ -463,6 +463,7 @@ arg_created_column=
 arg_database_file=
 arg_deleted_column=
 arg_insert_if_empty=
+arg_json_files=()
 arg_preserve_created=
 arg_primary_key_column=
 arg_soft_delete=
@@ -516,6 +517,10 @@ while [[ $# -gt 0 ]]; do
       arg_created_column+=":INTEGER"
     fi
     arg_column_specs+=("${arg_created_column}")
+    ;;
+  "--debug" ) # usage: enable debug mode
+    DEBUG=1
+    set -x
     ;;
   "--deleted-column" | "--deleted-column="* ) # usage: specify a column name to contain deletion timestamp. you also can specify column type (e.g. deleted_at:INTEGER)
     if [[ "$1" == *"="* ]]; then
@@ -605,13 +610,30 @@ while [[ $# -gt 0 ]]; do
     VERBOSE=1
     VERBOSITY="$(( VERBOSITY + 1 ))"
     ;;
+  "--"* | "-"* )
+    { echo "${0##*/}: unrecognized argument: ${1:-}"
+      echo
+    } | error
+    usage
+    exit 1
+    ;;
   * )
     if [[ -z "${arg_database_file:-}" ]]; then
       arg_database_file="${1:-}"
     elif [[ -z "${arg_table_name:-}" ]]; then
-      arg_table_name="${1:-}"
+      if validate_ident "${1:-}"; then
+        arg_table_name="${1:-}"
+      else
+        error "${0##*/}: invalid table name: ${1:-}"
+        exit 1
+      fi
     else
-      break
+      if [[ -e "${1:-}" ]]; then
+        arg_json_files+=("${1:-}")
+      else
+        error "${0##*/}: no such file: ${1:-}"
+        exit 1
+      fi
     fi
     ;;
   esac
@@ -629,15 +651,23 @@ if ! command -v sqlite3 1>/dev/null 2>&1; then
 fi
 
 if [[ -z "${arg_database_file:-}" ]]; then
+  { echo "${0##*/}: database file was not given"
+    echo
+  } | error
   usage
   exit 1
 fi
 
 if [[ -z "${arg_table_name:-}" ]]; then
+  { echo "${0##*/}: table name was not given"
+    echo
+  } | error
   usage
   exit 1
-else
-  validate_ident "${arg_table_name}"
+fi
+
+if [[ $# -gt 0 ]]; then
+  arg_json_files+=("$@")
 fi
 
 if [[ -z "${arg_primary_key_column:-}" ]]; then
@@ -649,7 +679,11 @@ fi
 
 # read json from remainder of command line arguments, or standard input
 json_file="$(mktemp "${TMPDIR}/json_file.XXXXXXXX")"
-cat "$@" > "${json_file}"
+if [[ ${#arg_json_files[*]} -eq 0 ]]; then
+  cat > "${json_file}"
+else
+  cat -- "${arg_json_files[@]}" > "${json_file}"
+fi
 
 # fail early if the input data is not well-formed
 json_file_length=0


### PR DESCRIPTION
Currently it's hard to recognize some typo in command line argument since the script is treating them as a filename to be passed to `cat(1)`. I want to show some explicit error message in that case.

At the same time, I want to maintain the script to be able to load JSON from weird filenames starting with `--`. Current idea is to use `--` as delimiter in that case `json2sqlite3 test.db test -- --weird-json-file.json`