### PR TITLE
Run before/after queryes even if the importing data set is empty for consistency on the behavior

### DIFF
--- a/bin/json2sqlite3
+++ b/bin/json2sqlite3
@@ -878,11 +878,25 @@ if [[ "${json_file_length:-0}" -eq 0 ]]; then
     validate_ident "${arg_primary_key_column%%:*}" "${arg_created_column%%:*}" "${arg_updated_column%%:*}" "${arg_deleted_column%%:*}"
     validate_type "${arg_primary_key_column#*:}" "${arg_created_column#*:}" "${arg_updated_column#*:}" "${arg_deleted_column#*:}"
     info "${0##*/}: empty file. attempt inserting negative cache record: ${arg_table_name}: ${pk_column_name}=${arg_insert_if_empty}" 1>&2
-    runq "${arg_database_file}" \
+    runq_args=( \
       ".mode list" \
       ".timeout ${SQLITE_BUSY_TIMEOUT}" \
       ".parameter set @arg_insert_if_empty '${arg_insert_if_empty}'" \
       "BEGIN TRANSACTION;" \
+    )
+
+    if [[ ${#arg_before_queries[@]} -gt 0 ]]; then
+      i=1
+      for q in "${arg_before_queries[@]}"; do
+        runq_args+=( \
+          "${q}" \
+          "SELECT @program_name || ': mutated ' || changes() || ' record(s) on before-query#${i}.' WHERE 0 < changes();" \
+        )
+        i=$((i+1))
+      done
+    fi
+
+    runq_args+=( \
       "INSERT OR IGNORE INTO \"${arg_table_name}\" (
          \"${arg_primary_key_column%%:*}\",
          \"${arg_created_column%%:*}\",
@@ -901,7 +915,22 @@ if [[ "${json_file_length:-0}" -eq 0 ]]; then
          \"${arg_deleted_column%%:*}\" = cast(strftime('%s') AS ${arg_deleted_column#*:})
        WHERE
          \"${arg_primary_key_column%%:*}\" = @arg_insert_if_empty;" \
-      "COMMIT TRANSACTION;" || true
+    )
+
+    if [[ ${#arg_after_queries[*]} -gt 0 ]]; then
+      i=1
+      for q in "${arg_after_queries[@]}"; do
+        runq_args+=( \
+          "${q}" \
+          "SELECT @program_name || ': mutated ' || changes() || ' record(s) on after-query#${i}.' WHERE 0 < changes();" \
+        )
+        i=$((i+1))
+      done
+    fi
+    runq_args+=( \
+      "COMMIT TRANSACTION;" \
+    )
+    runq "${arg_database_file}" "${runq_args[@]}" || true
     exit 0
   fi
 fi

--- a/tests/insert.bats
+++ b/tests/insert.bats
@@ -34,7 +34,7 @@ SQL
     --updated-column=_UpdatedAt \
     --deleted-column=_DeletedAt \
     --insert-if-empty=13 \
-    --after-query="SELECT format('after importing, there are %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    --after-query="SELECT 'after importing, there are ' || COUNT(1) ||' record(s).' FROM \"${table_name}\";" \
     "${database_file}" \
     "${table_name}" \
     < <(
@@ -61,7 +61,7 @@ SQL
     --updated-column=_UpdatedAt \
     --deleted-column=_DeletedAt \
     --insert-if-empty=13 \
-    --before-query="SELECT format('before importing, there were %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    --before-query="SELECT 'before importing, there were ' || COUNT(1) || ' record(s).' FROM \"${table_name}\";" \
     "${database_file}" \
     "${table_name}" \
     < <(
@@ -115,7 +115,7 @@ SQL
     --created-column=_CreatedAt \
     --updated-column=_UpdatedAt \
     --deleted-column=_DeletedAt \
-    --after-query="SELECT format('after importing, there are %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    --after-query="SELECT 'after importing, there are ' || COUNT(1) || ' record(s).' FROM \"${table_name}\";" \
     "${database_file}" \
     "${table_name}" \
     < <(
@@ -146,7 +146,7 @@ SQL
     --created-column=_CreatedAt \
     --updated-column=_UpdatedAt \
     --deleted-column=_DeletedAt \
-    --before-query="SELECT format('before importing, there were %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    --before-query="SELECT 'before importing, there were ' || COUNT(1) || ' record(s).' FROM \"${table_name}\";" \
     "${database_file}" \
     "${table_name}" \
     < <(

--- a/tests/insert.bats
+++ b/tests/insert.bats
@@ -22,6 +22,60 @@ EOS
   assert_success
 }
 
+@test "insert negative cache records w/ after query" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT, _CreatedAt INTEGER, _UpdatedAt INTEGER, _DeletedAt INTEGER);
+SQL
+  run json2sqlite3 \
+    --primary-key-column=_Id \
+    --created-column=_CreatedAt \
+    --updated-column=_UpdatedAt \
+    --deleted-column=_DeletedAt \
+    --insert-if-empty=13 \
+    --after-query="SELECT format('after importing, there are %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    "${database_file}" \
+    "${table_name}" \
+    < <(
+      jq --compact-output --null-input '[
+    ]'
+  )
+  assert_output <<EOS
+json2sqlite3: existing table '${table_name}' has schema compatible with columns detected in importing data.
+json2sqlite3: empty file. attempt inserting negative cache record: ${table_name}: _Id=13
+after importing, there are 1 record(s).
+EOS
+  assert_success
+}
+
+@test "insert negative cache records w/ before query" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT, _CreatedAt INTEGER, _UpdatedAt INTEGER, _DeletedAt INTEGER);
+SQL
+  run json2sqlite3 \
+    --primary-key-column=_Id \
+    --created-column=_CreatedAt \
+    --updated-column=_UpdatedAt \
+    --deleted-column=_DeletedAt \
+    --insert-if-empty=13 \
+    --before-query="SELECT format('before importing, there were %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    "${database_file}" \
+    "${table_name}" \
+    < <(
+      jq --compact-output --null-input '[
+    ]'
+  )
+  assert_output <<EOS
+json2sqlite3: existing table '${table_name}' has schema compatible with columns detected in importing data.
+json2sqlite3: empty file. attempt inserting negative cache record: ${table_name}: _Id=13
+before importing, there were 0 record(s).
+EOS
+  assert_success
+}
+
 @test "insert records into existing table" {
   database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
   table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
@@ -44,6 +98,68 @@ SQL
 1|FOO1||1234567890|1234567893|-1
 2|FOO2|BAR2|1234567891|1234567894|1234567897
 3|FOO3|BAR3|1234567892|1234567895|-1
+EOS
+  assert_success
+}
+
+@test "insert records into existing table w/ after query" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT, _CreatedAt INTEGER, _UpdatedAt INTEGER, _DeletedAt INTEGER);
+INSERT INTO "${table_name}" (_Id, foo, _CreatedAt, _UpdatedAt, _DeletedAt) VALUES (1, 'FOO1', 1234567890, 1234567893, -1);
+INSERT INTO "${table_name}" (_Id, foo, _CreatedAt, _UpdatedAt, _DeletedAt) VALUES (2, 'FOO2', -1, -1, -1);
+SQL
+  run json2sqlite3 \
+    --primary-key-column=_Id \
+    --created-column=_CreatedAt \
+    --updated-column=_UpdatedAt \
+    --deleted-column=_DeletedAt \
+    --after-query="SELECT format('after importing, there are %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    "${database_file}" \
+    "${table_name}" \
+    < <(
+    jq --compact-output --null-input '[
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2", "_CreatedAt":1234567891, "_UpdatedAt": 1234567894, "_DeletedAt": 1234567897},
+      {"_Id": 3, "foo": "FOO3", "bar": "BAR3", "_CreatedAt":1234567892, "_UpdatedAt": 1234567895, "_DeletedAt": -1}
+    ]'
+  )
+  assert_output <<EOS
+json2sqlite3: existing table '${table_name}' has schema compatible with columns detected in importing data.
+json2sqlite3: imported 2 record(s) into '${table_name}' table (existing table).
+after importing, there are 3 record(s).
+json2sqlite3: mutated 2 record(s) on after-query#1.
+EOS
+  assert_success
+}
+
+@test "insert records into existing table w/ before query" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT, _CreatedAt INTEGER, _UpdatedAt INTEGER, _DeletedAt INTEGER);
+INSERT INTO "${table_name}" (_Id, foo, _CreatedAt, _UpdatedAt, _DeletedAt) VALUES (1, 'FOO1', 1234567890, 1234567893, -1);
+INSERT INTO "${table_name}" (_Id, foo, _CreatedAt, _UpdatedAt, _DeletedAt) VALUES (2, 'FOO2', -1, -1, -1);
+SQL
+  run json2sqlite3 \
+    --primary-key-column=_Id \
+    --created-column=_CreatedAt \
+    --updated-column=_UpdatedAt \
+    --deleted-column=_DeletedAt \
+    --before-query="SELECT format('before importing, there were %d record(s).', COUNT(1)) FROM \"${table_name}\";" \
+    "${database_file}" \
+    "${table_name}" \
+    < <(
+    jq --compact-output --null-input '[
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2", "_CreatedAt":1234567891, "_UpdatedAt": 1234567894, "_DeletedAt": 1234567897},
+      {"_Id": 3, "foo": "FOO3", "bar": "BAR3", "_CreatedAt":1234567892, "_UpdatedAt": 1234567895, "_DeletedAt": -1}
+    ]'
+  )
+  assert_output <<EOS
+json2sqlite3: existing table '${table_name}' has schema compatible with columns detected in importing data.
+before importing, there were 2 record(s).
+json2sqlite3: mutated 1 record(s) on before-query#1.
+json2sqlite3: imported 2 record(s) into '${table_name}' table (existing table).
 EOS
   assert_success
 }


### PR DESCRIPTION
`--insert-if-empty` can populate some record (for negative caching sake) if the importing data set is empty. On the other hand, there are other command line options like `--before-query` and `--after-query` to run queries within the transaction before/after the import, however, so far they were not invoked in case the importing data set is empty.

To let the script behaving consistently regardless the length of the importing data set, this change is to ensure `--before-query` and `--after-query` even for the case the importing data set is empty.