### PR TITLE
Tolerate difference in case sensitivity on comparing table columns and JSON fields

### DIFF
--- a/bin/json2sqlite3
+++ b/bin/json2sqlite3
@@ -388,12 +388,15 @@ reconcile_column_specs3() {
         s2
       WHERE
         name IS NOT NULL AND name != ''
+        AND LOWER(name) NOT IN ( SELECT LOWER(name) FROM s1 )
       UNION SELECT
         name
       FROM
         s3
       WHERE
         name IS NOT NULL AND name != ''
+        AND LOWER(name) NOT IN ( SELECT LOWER(name) FROM s1 )
+        AND LOWER(name) NOT IN ( SELECT LOWER(name) FROM s2 )
     ), s0 AS (
       SELECT
         ( CASE
@@ -431,13 +434,13 @@ reconcile_column_specs3() {
         names
       LEFT JOIN
         s1
-          ON names.name = s1.name
+          ON LOWER(names.name) = LOWER(s1.name)
       LEFT JOIN
         s2
-          ON names.name = s2.name
+          ON LOWER(names.name) = LOWER(s2.name)
       LEFT JOIN
         s3
-          ON names.name = s3.name
+          ON LOWER(names.name) = LOWER(s3.name)
       ORDER BY
         cid
     ) SELECT
@@ -938,10 +941,10 @@ fi
 csv_file="$(mktemp "${TMPDIR}/csv_file.XXXXXXXX")"
 if jq --argjson current_column_specs "${current_column_specs:-[]}" --raw-output \
   'map(
-    . as $item |
+    (to_entries | map({key: (.key | ascii_downcase), value: .value}) | from_entries) as $item |
     $current_column_specs | map(
-      .name as $column_name |
-        (.type | ascii_upcase) as $column_type |
+      (.name | ascii_downcase) as $column_name |
+      (.type | ascii_upcase) as $column_type |
       if ($item[$column_name] | type == "null") then
         "\u00de\u00ad\u00be\u00efNULL" # converting JSON null into internal representation of NULL (w/ magic bytes) to insert SQLite3 NULL from CSV...
       else

--- a/tests/alter_table.bats
+++ b/tests/alter_table.bats
@@ -55,6 +55,31 @@ EOS
   assert_success
 }
 
+@test "alter existing table with case insensitivity on column names" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER, Foo TEXT, BAR TEXT);
+SQL
+  run json2sqlite3 "${database_file}" "${table_name}" < <(
+    jq --compact-output --null-input '[
+      {"_Id": 1, "foo": "FOO1", "bar": "BAR1"},
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2"},
+      {"_Id": 3, "foo": "FOO3", "bar": "BAR3"}
+    ]'
+  )
+  assert_success
+  run sqlite3 "${database_file}" <<SQL
+SELECT * FROM "${table_name}" ORDER BY _Id;
+SQL
+  assert_output <<EOS
+1|FOO1|BAR1
+2|FOO2|BAR2
+3|FOO3|BAR3
+EOS
+  assert_success
+}
+
 @test "alter existing table with primary key" {
   database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
   table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"


### PR DESCRIPTION
SQLite3 (or, more generally SQL) doesn't enforce case sensitivity on its table columns. Although so far the script was implemented to compare table column names and JSON object fields in case sensitive manner.

This let the script to tolerate the difference in capitalization on table columns.