### PR TITLE
Support importing data formated in "jsonl"

### DIFF
--- a/bin/json2sqlite3
+++ b/bin/json2sqlite3
@@ -520,6 +520,7 @@ arg_created_column=
 arg_database_file=
 arg_deleted_column=
 arg_dump_intermediate_csv=
+arg_format="json"
 arg_insert_if_empty=
 arg_json_files=()
 arg_preserve_created=
@@ -600,6 +601,14 @@ while [[ $# -gt 0 ]]; do
       arg_dump_intermediate_csv="${1#*=}"
     else
       arg_dump_intermediate_csv="${2:-}"
+      shift 1
+    fi
+    ;;
+  "--format" | "--format="* ) # usage: specify input data format (json/jsonl) (default: json)
+    if [[ "$1" == *"="* ]]; then
+      arg_format="${1#*=}"
+    else
+      arg_format="${2:-}"
       shift 1
     fi
     ;;
@@ -746,11 +755,26 @@ fi
 
 # read json from remainder of command line arguments, or standard input
 json_file="$(mktemp "${TMPDIR}/json_file.XXXXXXXX")"
-if [[ ${#arg_json_files[*]} -eq 0 ]]; then
-  cat > "${json_file}"
-else
-  cat -- "${arg_json_files[@]}" > "${json_file}"
-fi
+case "${arg_format:-}" in
+"json" )
+  if [[ ${#arg_json_files[*]} -eq 0 ]]; then
+    cat > "${json_file}"
+  else
+    cat -- "${arg_json_files[@]}" > "${json_file}"
+  fi
+  ;;
+"jsonl" )
+  if [[ ${#arg_json_files[*]} -eq 0 ]]; then
+    jq --slurp '.' > "${json_file}"
+  else
+    jq --slurp '.' -- "${arg_json_files[@]}" > "${json_file}"
+  fi
+  ;;
+* )
+  error "${0##*/}: unsupported format was specified: ${arg_format:-} (valid values: json, jsonl)"
+  exit 1
+  ;;
+esac
 
 # fail early if the input data is not well-formed
 json_file_length=0

--- a/tests/format.bats
+++ b/tests/format.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "insert with json format" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT);
+SQL
+  run json2sqlite3 --primary-key-column=_Id --format=json "${database_file}" "${table_name}" < <(
+    jq --compact-output --null-input '[
+      {"_Id": 1, "foo": "FOO1", "bar": "BAR1"},
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2"}
+    ]'
+  )
+  assert_success
+  run sqlite3 "${database_file}" <<SQL
+SELECT _Id, foo, bar FROM "${table_name}" ORDER BY _Id;
+SQL
+  assert_output <<EOS
+1|FOO1|BAR1
+2|FOO2|BAR2
+EOS
+  assert_success
+}
+
+@test "insert with jsonl format" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT);
+SQL
+  run json2sqlite3 --primary-key-column=_Id --format=jsonl "${database_file}" "${table_name}" < <(
+    jq --compact-output --null-input '[
+      {"_Id": 1, "foo": "FOO1", "bar": "BAR1"},
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2"}
+    ][]'
+  )
+  assert_success
+  run sqlite3 "${database_file}" <<SQL
+SELECT _Id, foo, bar FROM "${table_name}" ORDER BY _Id;
+SQL
+  assert_output <<EOS
+1|FOO1|BAR1
+2|FOO2|BAR2
+EOS
+  assert_success
+}
+
+@test "insert with unsupported format" {
+  database_file="$(generate_database_file "${BATS_TEST_FILENAME##*/}")"
+  table_name="$(generate_table_name "${BATS_TEST_FILENAME##*/}")"
+  sqlite3 "${database_file}" <<SQL
+CREATE TABLE "${table_name}" (_Id INTEGER PRIMARY KEY, foo TEXT, bar TEXT);
+SQL
+  run json2sqlite3 --primary-key-column=_Id --format=unsupported "${database_file}" "${table_name}" < <(
+    jq --compact-output --null-input '[
+      {"_Id": 1, "foo": "FOO1", "bar": "BAR1"},
+      {"_Id": 2, "foo": "FOO2", "bar": "BAR2"}
+    ]'
+  )
+  assert_failure
+}


### PR DESCRIPTION
Sometimes it's convenient if I can import record formatted in `jsonl` format (JSON objects concatenated with newline). Technically it's just converting `jsonl` data into a JSON array.